### PR TITLE
🐛 Logging error instead of debug in `convertToGrpcError`

### DIFF
--- a/server/grpc/error.go
+++ b/server/grpc/error.go
@@ -24,7 +24,7 @@ func ConvertToGrpcError(ctx context.Context, error *server.Error) error {
 		error.Message = seriousErrorMsg
 	} else {
 		log.Ctx(ctx).
-			Debug().
+			Error().
 			Err(error.Error).
 			Interface("statusCode", error.StatusCode).
 			Msg(error.Message)


### PR DESCRIPTION
@nandiheath @Disturbing need to discuss about this.
I don't think the function in utils should log anything. Cuz it's using `zerolog` while we might use it and use a different logger. So the log should be done on our end in each app