### PR TITLE
:alien: feat(MaxMsg): support to increase grpc msg size

### DIFF
--- a/server/grpc/client.go
+++ b/server/grpc/client.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-func CreateConnectionOrDie(host string, isTLS bool) *grpc.ClientConn {
+func getDialOptionSecurity(isTLS bool) grpc.DialOption {
 	dialOption := grpc.WithInsecure()
 
 	if isTLS {
@@ -15,9 +15,28 @@ func CreateConnectionOrDie(host string, isTLS bool) *grpc.ClientConn {
 		pool, _ := x509.SystemCertPool()
 		creds := credentials.NewClientTLSFromCert(pool, "")
 		dialOption = grpc.WithTransportCredentials(creds)
+
 	}
 
-	conn, err := grpc.Dial(host, dialOption)
+	return dialOption
+}
+
+func CreateConnectionOrDie(host string, isTLS bool) *grpc.ClientConn {
+	conn, err := grpc.Dial(host, getDialOptionSecurity(isTLS))
+
+	if err != nil {
+		log.Panic().Msgf("could not create grpc connection to %v - %v", host, err)
+	}
+
+	return conn
+}
+
+func CreateConnectionWithMaxMsgSizeOrDie(host string, isTLS bool, maxMsgSizeInBytes int) *grpc.ClientConn {
+	conn, err := grpc.Dial(
+		host,
+		getDialOptionSecurity(isTLS),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSizeInBytes)),
+	)
 
 	if err != nil {
 		log.Panic().Msgf("could not create grpc connection to %v - %v", host, err)


### PR DESCRIPTION
Ran into an issue where our msg size was too small to get billing data. This was for 9 days of data on kubernetes lvl, so my guess is we will run into limitations in the future, so we will make this big and i will add warnings on the reporter lvl when we are getting close to it.

