### PR TITLE
🌟feat: add generic hex string shorten function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/improbable-eng/grpc-web v0.12.0
+	github.com/joho/godotenv v1.3.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/rs/zerolog v1.18.0
+	github.com/stretchr/testify v1.4.0
 	google.golang.org/grpc v1.29.1
+	gopkg.in/errgo.v2 v2.1.0
 )

--- a/utils/string.go
+++ b/utils/string.go
@@ -63,8 +63,17 @@ func ShortenUUID8(uuid string) (string, error) {
 	return hex.EncodeToString(returnBytes), nil
 }
 
+/**
+This will shorten the input string to len [outputLen], with bitwise xor the bytes
+The length of the input string/outputLen must be both even number,
+And outputLen must be a positive and even divisor of the input length, and cannot be 1 or input length
+i.e. if input length is 24, outputLen can be 12,8,6,4,2. but cannot be 24, 3, 1
+
+This function will try to ensure the distribution of the randomness from the given input.
+But again, like the function ShortenUUID16 above, this will increase the possibility on collision, especially when the outputLen is too short
+*/
 func ShortenHexString(input string, outputLen int) (string, error) {
-	if len(input)%2 != 0 || outputLen %2 != 0{
+	if len(input)%2 != 0 || outputLen%2 != 0 {
 		return "", fmt.Errorf("input/output must have even number characters")
 	}
 
@@ -91,7 +100,6 @@ func ShortenHexString(input string, outputLen int) (string, error) {
 
 	return hex.EncodeToString(returnBytes), nil
 }
-
 
 // Random string function from stackoverflow
 // not the best one but it is simple

--- a/utils/string.go
+++ b/utils/string.go
@@ -92,51 +92,6 @@ func ShortenHexString(input string, outputLen int) (string, error) {
 	return hex.EncodeToString(returnBytes), nil
 }
 
-/**
-will safely execute inside of a go routine with recovery
-*/
-func SafeGoRoutine(fn func() error, args ...interface{}) {
-	go func() {
-		defer func() {
-			if err := recover(); err != nil {
-				stack := make([]byte, 1024*8)
-				stack = stack[:runtime.Stack(stack, false)]
-
-				f := "panic in routine: %s\n%s"
-				logger.Errorf(f, err, stack)
-			}
-		}()
-
-		err := fn()
-
-		if err != nil {
-			logger.Errorf("err in routine: %s", err)
-		}
-	}()
-}
-
-/**
-will safely execute inside of a go routine with recovery
-*/
-func SafeGoRoutineParams(fn func(params ...interface{}) error, args ...interface{}) {
-	go func() {
-		defer func() {
-			if err := recover(); err != nil {
-				stack := make([]byte, 1024*8)
-				stack = stack[:runtime.Stack(stack, false)]
-
-				f := "panic in routine: %s\n%s"
-				logger.Errorf(f, err, stack)
-			}
-		}()
-
-		err := fn(args...)
-
-		if err != nil {
-			logger.Errorf("err in routine: %s", err)
-		}
-	}()
-}
 
 // Random string function from stackoverflow
 // not the best one but it is simple

--- a/utils/string_test.go
+++ b/utils/string_test.go
@@ -2,6 +2,7 @@ package utils_test
 
 import (
 	"github.com/kintohub/utils-go/utils"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -98,6 +99,79 @@ func TestShortenUUID8(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ShortenUUID8() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortenHexString(t *testing.T) {
+	type args struct {
+		input     string
+		outputLen int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test success",
+			args: args{
+				input:     "5f28eb526ffc3d5051ad2fd5",
+				outputLen: 12,
+			},
+			want:    "6278baff4029",
+			wantErr: false,
+		},
+		{
+			name: "test success",
+			args: args{
+				input:     "5f28eb526ffc3d5051ad2fd5",
+				outputLen: 2,
+			},
+			want:    "36",
+			wantErr: false,
+		},
+		{
+			name: "test success",
+			args: args{
+				input:     "5f28eb526ffc3d5051ad2fd5",
+				outputLen: 6,
+			},
+			want:    "9d3893",
+			wantErr: false,
+		},
+		{
+			name: "test error if outputLen not dividend",
+			args: args{
+				input:     "5f28eb526ffc3d5051ad2fd5",
+				outputLen: 14,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "test error if outputLen not even",
+			args: args{
+				input:     "5f28eb526ffc3d5051ad2fd5",
+				outputLen: 3,
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ShortenHexString(tt.args.input, tt.args.outputLen)
+
+			if (err != nil) != tt.wantErr {
+				assert.Equal(t, len(got), tt.args.outputLen)
+				t.Errorf("ShortenHexString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ShortenHexString() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/utils/string_test.go
+++ b/utils/string_test.go
@@ -163,7 +163,7 @@ func TestShortenHexString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ShortenHexString(tt.args.input, tt.args.outputLen)
+			got, err := utils.ShortenHexString(tt.args.input, tt.args.outputLen)
 
 			if (err != nil) != tt.wantErr {
 				assert.Equal(t, len(got), tt.args.outputLen)


### PR DESCRIPTION
make a generic version for shortenUUID8/shortenUUID16 for shortening other hex string (e.g. mongoId)