### PR TITLE
🌟feat: enhance debug

### DIFF
--- a/server/grpc/error.go
+++ b/server/grpc/error.go
@@ -34,7 +34,7 @@ func ConvertToGrpcError(ctx context.Context, error *server.Error) error {
 }
 
 func panicRecoveryHandler(v interface{}) error {
-	log.Error().Msgf("[IMPORTANT] a uncaught panic occurred: %v", v)
+	log.Error().Stack().Msgf("[IMPORTANT] a uncaught panic occurred: %v", v)
 	return grpcStatus.Error(grpcCodes.Internal, seriousErrorMsg)
 }
 

--- a/server/grpc/error.go
+++ b/server/grpc/error.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"github.com/kintohub/utils-go/server"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
@@ -34,8 +35,10 @@ func ConvertToGrpcError(ctx context.Context, error *server.Error) error {
 }
 
 func panicRecoveryHandler(v interface{}) error {
-	log.Error().Msg("Test")
-	log.Error().Stack().Msgf("[IMPORTANT] a uncaught panic occurred: %v", v)
+	log.Error().
+		Stack().
+		Err(errors.WithStack(v.(error))).
+		Msgf("[IMPORTANT] a uncaught panic occurred: %v", v)
 	return grpcStatus.Error(grpcCodes.Internal, seriousErrorMsg)
 }
 

--- a/server/grpc/error.go
+++ b/server/grpc/error.go
@@ -34,6 +34,7 @@ func ConvertToGrpcError(ctx context.Context, error *server.Error) error {
 }
 
 func panicRecoveryHandler(v interface{}) error {
+	log.Error().Msg("Test")
 	log.Error().Stack().Msgf("[IMPORTANT] a uncaught panic occurred: %v", v)
 	return grpcStatus.Error(grpcCodes.Internal, seriousErrorMsg)
 }

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -58,13 +58,16 @@ func runGrpcWebServer(server *grpc.Server, port, coresAllowedHosts string) {
 	log.Info().Msgf("Listening to :%s for grpc-web connection requests", port)
 
 	panic(http.ListenAndServe(":"+port, http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		if wrappedGrpc.IsGrpcWebRequest(req) {
-			wrappedGrpc.ServeHTTP(resp, req)
-		}
 
 		resp.Header().Set("Access-Control-Allow-Origin", coresAllowedHosts)
 		resp.Header().Set("Access-Control-Allow-Headers", coresAllowedHosts)
 
-		resp.WriteHeader(http.StatusOK)
+		if wrappedGrpc.IsGrpcWebRequest(req) {
+			// we assume the handler already take care the status code
+			wrappedGrpc.ServeHTTP(resp, req)
+		} else {
+			// handle OPTION requests to always return 200
+			resp.WriteHeader(http.StatusOK)
+		}
 	})))
 }


### PR DESCRIPTION
- fix superfluous response warning messages
- add stack trace when there is an uncaught exception

will show
```
 ERR panic error="runtime error: invalid memory address or nil pointer dereference" stack=[{"func":"panicRecoveryHandler","line":"40","source":"error.go"},{"func":"WithRecoveryHandler.func1.1","line":"33","source":"options.go"},...
```

instead of 
```
 ERR panic error="runtime error: invalid memory address or nil pointer dereference" 
```