### PR TITLE
✨ feat(github): add all the logic to the github module and expose public methods only 

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -53,28 +53,29 @@ func (g *github) GetUserAccessToken(code string) (string, error) {
 	}
 
 	githubUrl := getUrl(BASE_URL, "/login/oauth/access_token", "")
+	body, err := g.callGithub(githubUrl, "POST", "", false, requestBody)
+	bodyStr := string(body)
+
+	if err != nil {
+		klog.ErrorfWithErr(err, "Github error getting access token: %v", bodyStr)
+		return "", errors.New("Error getting access token from github.")
+	}
 	// Response is encoded as x-www-form-urlencoded so we parse it
 	// as a url segment by adding `?` at the beginning
-	body, err := g.callGithub(githubUrl, "POST", "", false, requestBody)
-	if err != nil {
-		return "", fmt.Errorf("Error getting access token from github. %v", err)
-	}
-	bodyStr := "?" + string(body)
-	parsedUrl, err := url.Parse(bodyStr)
+	parsedUrl, err := url.Parse("?" + bodyStr)
 	parseErr := errors.New("Error parsing github response.")
 	if err != nil {
-		klog.Errorf("Github error parsing response: %v", bodyStr)
+		klog.Errorf("Github error parsing get token response: %v", bodyStr)
 		return "", parseErr
 	}
 
 	parsedQuery, err := url.ParseQuery(parsedUrl.RawQuery)
 	if err != nil {
-		klog.Errorf("Github error parsing response: %v", bodyStr)
+		klog.Errorf("Github error parsing get token response: %v", bodyStr)
 		return "", parseErr
 	}
 
 	accessToken := parsedQuery["access_token"]
-
 	if len(accessToken) == 0 {
 		klog.Errorf("Github error parsing response: %v", bodyStr)
 		return "", parseErr

--- a/github/github.go
+++ b/github/github.go
@@ -18,10 +18,11 @@ type GithubInterface interface {
 }
 
 type github struct {
-	acceptHeader  string
-	appId         string
-	appSecret     string
-	appPrivateKey []byte
+	acceptHeader    string
+	appId           string
+	appClientId     string
+	appClientSecret string
+	appPrivateKey   []byte
 }
 
 var (
@@ -29,12 +30,13 @@ var (
 	BASE_URL_PLAIN = "https://github.com"
 )
 
-func New(appId, appSecret string, appPrivateKey []byte) GithubInterface {
+func New(appId, appClientId, appClientSecret string, appPrivateKey []byte) GithubInterface {
 	g := &github{
-		acceptHeader:  "application/vnd.github.machine-man-preview+json",
-		appId:         appId,
-		appPrivateKey: appPrivateKey, // this is user when autheticating as the github app (when cloning)
-		appSecret:     appSecret,
+		acceptHeader:    "application/vnd.github.machine-man-preview+json",
+		appId:           appId,
+		appClientId:     appClientId,
+		appClientSecret: appClientSecret,
+		appPrivateKey:   appPrivateKey, // this is user when autheticating as the github app (when cloning)
 	}
 	return g
 }
@@ -51,8 +53,8 @@ type githubUserAccess struct {
 
 func (g *github) GetUserAccessToken(code string) (string, error) {
 	requestBody := githubUserAccessRequest{
-		ClientId:     g.appId,
-		ClientSecret: g.appSecret,
+		ClientId:     g.appClientId,
+		ClientSecret: g.appClientSecret,
 		Code:         code,
 	}
 

--- a/github/github.go
+++ b/github/github.go
@@ -28,8 +28,8 @@ type github struct {
 }
 
 var (
-	BASE_URL                 = "https://api.github.com"
-	BASE_URL_PLAIN           = "https://github.com"
+	BASE_API_URL             = "https://api.github.com"
+	BASE_URL                 = "https://github.com"
 	TEMP_ACCEPT_HEADER_VALUE = "application/vnd.github.machine-man-preview+json"
 )
 
@@ -56,7 +56,7 @@ func (g *github) GetUserAccessToken(code string) (string, error) {
 		Code:         code,
 	}
 
-	githubUrl := getUrl(BASE_URL_PLAIN, "/login/oauth/access_token", "")
+	githubUrl := getUrl(BASE_URL, "/login/oauth/access_token", "")
 	// Response is encoded as x-www-form-urlencoded so we parse it
 	// as a url segment by adding `?` at the beginning
 	body, err := g.callGithub(githubUrl, "POST", "", false, requestBody)
@@ -102,7 +102,7 @@ func (g *github) GetListRepos(page int32, installationId, userAccessToken string
 		query = fmt.Sprintf("page=%d", page)
 	}
 	endpoint := fmt.Sprintf("/user/installations/%v/repositories", installationId)
-	url := getUrl(BASE_URL, endpoint, query)
+	url := getUrl(BASE_API_URL, endpoint, query)
 
 	body, err :=
 		g.callGithub(url, "GET", genAuthToken(userAccessToken), true, nil)
@@ -125,7 +125,7 @@ type GithubUserInfo struct {
 }
 
 func (g *github) GetUserInformation(userAccessToken string) (*GithubUserInfo, error) {
-	url := getUrl(BASE_URL, "/user", "")
+	url := getUrl(BASE_API_URL, "/user", "")
 	body, err :=
 		g.callGithub(url, "GET", genAuthToken(userAccessToken), true, nil)
 	bodyStr := string(body)
@@ -209,7 +209,7 @@ func (g *github) generateInstallationToken(installationId string) (string, error
 	}
 
 	endpoint := fmt.Sprintf("/app/installations/%v/access_tokens", installationId)
-	url := getUrl(BASE_URL, endpoint, "")
+	url := getUrl(BASE_API_URL, endpoint, "")
 
 	body, err := g.callGithub(url, "POST", genAuthBearer(jwtToken), true, nil)
 	if err != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -139,7 +139,6 @@ func (g *github) GetUserInformation(userAccessToken string) (*GithubUserInfo, er
 		klog.ErrorfWithErr(err, "Github parsing github response for getting user info: %v", bodyStr)
 		return nil, errors.New("Error parsing github response for getting user info.")
 	}
-	klog.Infof("WHAT IS HAPPENING: username: %v, email: %v", userInfo.Username, userInfo.Email)
 	return &userInfo, nil
 }
 

--- a/github/github.go
+++ b/github/github.go
@@ -21,8 +21,8 @@ type GithubInterface interface {
 }
 
 type github struct {
-	appId           string
-	appClientId     string
+	appID           string
+	appClientID     string
 	appClientSecret string
 	appPrivateKey   []byte
 }
@@ -33,10 +33,10 @@ var (
 	TEMP_ACCEPT_HEADER_VALUE = "application/vnd.github.machine-man-preview+json"
 )
 
-func New(appId, appClientId, appClientSecret string, appPrivateKey []byte) GithubInterface {
+func New(appID, appClientID, appClientSecret string, appPrivateKey []byte) GithubInterface {
 	g := &github{
-		appId:           appId,
-		appClientId:     appClientId,
+		appID:           appID,
+		appClientID:     appClientID,
 		appClientSecret: appClientSecret,
 		appPrivateKey:   appPrivateKey, // this is user when autheticating as the github app (when cloning)
 	}
@@ -44,14 +44,14 @@ func New(appId, appClientId, appClientSecret string, appPrivateKey []byte) Githu
 }
 
 type githubUserAccessRequest struct {
-	ClientId     string `json:"client_id"`
+	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	Code         string `json:"code"`
 }
 
 func (g *github) GetUserAccessToken(code string) (string, error) {
 	requestBody := githubUserAccessRequest{
-		ClientId:     g.appClientId,
+		ClientID:     g.appClientID,
 		ClientSecret: g.appClientSecret,
 		Code:         code,
 	}
@@ -234,7 +234,7 @@ func (g *github) generateJWTToken() (string, error) {
 	claims := jwt.StandardClaims{
 		IssuedAt:  time.Now().Unix(),
 		ExpiresAt: time.Now().Add(time.Minute * 10).Unix(),
-		Issuer:    g.appId,
+		Issuer:    g.appID,
 	}
 
 	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(g.appPrivateKey))


### PR DESCRIPTION
**What this PR includes:**
- Refactor the whole module
- Move alot of the settings to be part of the module, like accept headers and base URL 
- Add all the logic for processing parsing the main github endpoints, and make all the low lvl endpoints private 

Related to the [PR](https://github.com/kintohub/kinto-enterprise/pull/47) from kinto-enterprise 
Related to: ch-981


----

Update:
Remove get installation id, now we are storing the user access token, the user can directly access the endpoints using that token
